### PR TITLE
corrected launch_path

### DIFF
--- a/client/src/manifest.webapp
+++ b/client/src/manifest.webapp
@@ -2,7 +2,7 @@
   "version": "0.3",
   "name": "Foxmote",
   "description": "Yet another XBMC remote for firefox os, compatible frodo and above.",
-  "launch_path": "/index.html",
+  "launch_path": "/foxmote/",
   "icons": {
     "30": "/img/icons/foxmote-30.png",
     "32": "/img/icons/foxmote-32.png",


### PR DESCRIPTION
I've tried to test the foxmote app from the firefox marketplace on my Geeksphone Keon. After launching the app I only got the directory listing. I think this pull request should fix the issue.
